### PR TITLE
Update wgpu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,12 +520,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "d3d12"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f0de2f5a8e7bd4a9eec0e3c781992a4ce1724f68aec7d7a3715344de8b39da"
+checksum = "e16e44ab292b1dddfdaf7be62cfd8877df52f2f3fde5858d95bab606be259f20"
 dependencies = [
- "bitflags 1.3.2",
- "libloading 0.7.4",
+ "bitflags 2.4.1",
+ "libloading 0.8.1",
  "winapi",
 ]
 
@@ -772,7 +772,7 @@ dependencies = [
  "bindgen",
  "cgl",
  "egl",
- "glutin_wgl_sys",
+ "glutin_wgl_sys 0.4.0",
  "winapi",
 ]
 
@@ -821,6 +821,9 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
  "spin",
 ]
 
@@ -968,8 +971,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc 0.2.151",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1016,9 +1021,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "glow"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0fe580e4b60a8ab24a868bc08e2f03cbcb20d3d676601fa909386713333728"
+checksum = "886c2a30b160c4c6fec8f987430c26b526b7988ca71f664e6a699ddf6f9601e4"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -1039,7 +1044,7 @@ dependencies = [
  "dispatch",
  "glutin_egl_sys",
  "glutin_glx_sys",
- "glutin_wgl_sys",
+ "glutin_wgl_sys 0.4.0",
  "libloading 0.7.4",
  "objc2",
  "once_cell",
@@ -1091,6 +1096,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "glutin_wgl_sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
 name = "glyph-names"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,31 +1112,32 @@ checksum = "c3531d702d6c1a3ba92a5fb55a404c7b8c476c8e7ca249951077afcbe4bc807f"
 
 [[package]]
 name = "gpu-alloc"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22beaafc29b38204457ea030f6fb7a84c9e4dd1b86e311ba0542533453d87f62"
+checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "gpu-alloc-types",
 ]
 
 [[package]]
 name = "gpu-alloc-types"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54804d0d6bc9d7f26db4eaec1ad10def69b599315f487d32c334a80d1efe67a5"
+checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
 ]
 
 [[package]]
 name = "gpu-allocator"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce95f9e2e11c2c6fadfce42b5af60005db06576f231f5c92550fdded43c423e8"
+checksum = "40fe17c8a05d60c38c0a4e5a3c802f2f1ceb66b76c67d96ffb34bef0475a7fad"
 dependencies = [
  "backtrace",
  "log",
+ "presser",
  "thiserror",
  "winapi",
  "windows",
@@ -1136,7 +1151,7 @@ checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
 dependencies = [
  "bitflags 2.4.1",
  "gpu-descriptor-types",
- "hashbrown 0.14.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1156,12 +1171,6 @@ checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
 dependencies = [
  "crunchy",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1236,22 +1245,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1334,12 +1333,12 @@ dependencies = [
 
 [[package]]
 name = "khronos-egl"
-version = "4.1.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
  "libc 0.2.151",
- "libloading 0.7.4",
+ "libloading 0.8.1",
  "pkg-config",
 ]
 
@@ -1536,25 +1535,26 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de11355d1f6781482d027a3b4d4de7825dcedb197bf573e0596d00008402d060"
-dependencies = [
- "bitflags 1.3.2",
- "block",
- "core-graphics-types",
- "foreign-types 0.3.2",
- "log",
- "objc",
-]
-
-[[package]]
-name = "metal"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "550b24b0cd4cf923f36bae78eca457b3a10d8a6a14a9c84cb2687b527e6a84af"
 dependencies = [
  "bitflags 1.3.2",
+ "block",
+ "core-graphics-types",
+ "foreign-types 0.5.0",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
+name = "metal"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+dependencies = [
+ "bitflags 2.4.1",
  "block",
  "core-graphics-types",
  "foreign-types 0.5.0",
@@ -1593,15 +1593,15 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.12.3"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbcc2e0513220fd2b598e6068608d4462db20322c0e77e47f6f488dfcfc279cb"
+checksum = "ae585df4b6514cf8842ac0f1ab4992edc975892704835b549cf818dc0191249e"
 dependencies = [
  "bit-set",
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "codespan-reporting",
  "hexf-parse",
- "indexmap 1.9.3",
+ "indexmap",
  "log",
  "num-traits",
  "rustc-hash",
@@ -1609,6 +1609,15 @@ dependencies = [
  "termcolor",
  "thiserror",
  "unicode-xid",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -1965,6 +1974,12 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "prettyplease"
@@ -2478,7 +2493,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap",
  "toml_datetime",
  "winnow",
 ]
@@ -2724,9 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2740,12 +2755,13 @@ checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "wgpu"
-version = "0.16.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "480c965c9306872eb6255fa55e4b4953be55a8b64d57e61d7ff840d3dcc051cd"
+checksum = "30e7d227c9f961f2061c26f4cb0fbd4df0ef37e056edd0931783599d6c94ef24"
 dependencies = [
  "arrayvec",
  "cfg-if",
+ "flume",
  "js-sys",
  "log",
  "naga",
@@ -2764,9 +2780,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f478237b4bf0d5b70a39898a66fa67ca3a007d79f2520485b8b0c3dfc46f8c2"
+checksum = "ef91c1d62d1e9e81c79e600131a258edf75c9531cbdbde09c44a011a47312726"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -2787,9 +2803,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.16.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecb3258078e936deee14fd4e0febe1cfe9bbb5ffef165cb60218d2ee5eb4448"
+checksum = "b84ecc802da3eb67b4cf3dd9ea6fe45bbb47ef13e6c49c5c3240868a9cc6cdd9"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -2799,8 +2815,8 @@ dependencies = [
  "block",
  "core-graphics-types",
  "d3d12",
- "foreign-types 0.3.2",
  "glow",
+ "glutin_wgl_sys 0.5.0",
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
@@ -2810,9 +2826,10 @@ dependencies = [
  "libc 0.2.151",
  "libloading 0.8.1",
  "log",
- "metal 0.24.0",
+ "metal 0.27.0",
  "naga",
  "objc",
+ "once_cell",
  "parking_lot",
  "profiling",
  "range-alloc",
@@ -2829,18 +2846,19 @@ dependencies = [
 
 [[package]]
 name = "wgpu-profiler"
-version = "0.12.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8545365935dee884288860abc2a6920e904fff8a188205a848234376664796"
+checksum = "cbdc78911971a06b86a57a9a8e1c861fbc90c62dcbc96bff0b2831c1e853b7bd"
 dependencies = [
+ "thiserror",
  "wgpu",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "0.16.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c153280bb108c2979eb5c7391cb18c56642dd3c072e55f52065e13e2a1252a"
+checksum = "0d5ed5f0edf0de351fe311c53304986315ce866f394a2e6df0c4b3c70774bcdd"
 dependencies = [
  "bitflags 2.4.1",
  "js-sys",
@@ -2898,11 +2916,21 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.44.0"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
+checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
 dependencies = [
- "windows-targets 0.42.2",
+ "windows-core",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ members     = [
     "draw",
 ]
 
+[workspace.dependencies]
+wgpu = "0.18"
+wgpu-profiler = "0.15"
+
 [patch.crates-io]
 flo_canvas              = { path = "./canvas" }
 flo_canvas_events       = { path = "./canvas_events" }

--- a/draw/Cargo.toml
+++ b/draw/Cargo.toml
@@ -37,8 +37,8 @@ raw-window-handle   = { optional = true, version = "0.5" }
 gl                  = { optional = true, version = "0.14" }
 
 winit               = { optional = true, version = "0.28" }
-wgpu                = { optional = true, version = "0.16" }
-wgpu-profiler       = { version = "0.12", optional = true }
+wgpu                = { optional = true, workspace = true }
+wgpu-profiler       = { workspace = true, optional = true }
 
 [dev-dependencies]
 flo_curves          = "0.8"

--- a/draw/src/draw_scene/glutin_render_window_entity.rs
+++ b/draw/src/draw_scene/glutin_render_window_entity.rs
@@ -14,6 +14,7 @@ use std::sync::*;
 ///
 /// Creates a render window in a scene with the specified entity ID
 ///
+#[allow(dead_code)]
 pub fn create_glutin_render_window_entity(context: &Arc<SceneContext>, entity_id: EntityId, initial_size: (u64, u64)) -> Result<SimpleEntityChannel<RenderWindowRequest>, CreateEntityError> {
     // This window can accept a couple of converted messages
     context.convert_message::<RenderRequest, RenderWindowRequest>()?;

--- a/draw/src/draw_scene/glutin_scene.rs
+++ b/draw/src/draw_scene/glutin_scene.rs
@@ -1,7 +1,7 @@
 use crate::glutin::*;
 
 use futures::prelude::*;
-use once_cell::sync::{Lazy};
+use once_cell::sync::Lazy;
 
 use flo_scene::*;
 
@@ -13,6 +13,7 @@ static DRAW_SCENE_CONTEXT: Lazy<Mutex<Option<Arc<SceneContext>>>> = Lazy::new(||
 ///
 /// Retrieves or creates a scene context for flo_draw
 ///
+#[allow(dead_code)]
 pub fn flo_draw_glutin_scene_context() -> Arc<SceneContext> {
     let mut context = DRAW_SCENE_CONTEXT.lock().unwrap();
 

--- a/draw/src/wgpu/winit_window.rs
+++ b/draw/src/wgpu/winit_window.rs
@@ -99,7 +99,7 @@ where
                         let winit_window    = &**winit_window;
 
                         let backend         = wgpu::util::backend_bits_from_env().unwrap_or_else(|| wgpu::Backends::PRIMARY);
-                        let instance        = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: backend, dx12_shader_compiler: wgpu::Dx12Compiler::default() });
+                        let instance        = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: backend, ..Default::default() });
                         let surface         = unsafe { instance.create_surface(winit_window).expect("wgpu surface") };
                         let adapter         = instance.request_adapter(&wgpu::RequestAdapterOptions {
                             power_preference:       wgpu::PowerPreference::default(),

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -22,7 +22,7 @@ bindgen = "0.66"
 
 [dependencies]
 gl                      = { version = "0.14", optional = true }
-wgpu                    = { version = "0.16", optional = true }
+wgpu                    = { workspace = true, optional = true }
 metal                   = { version = "0.25", optional = true }
 cocoa                   = { version = "0.25", optional = true }
 libc                    = { version = "0.2", optional = true }
@@ -31,7 +31,7 @@ flo_render_gl_offscreen = { version = "0.4", optional = true }
 desync                  = { version = "0.9", optional = true }
 once_cell               = { version = "1.18", optional = true }
 futures                 = { version = "0.3", optional = true }
-wgpu-profiler           = { version = "0.12", optional = true }
+wgpu-profiler           = { workspace = true, optional = true }
 
 [dev-dependencies]
 winit                   = "0.28"

--- a/render/examples/raw_wgpu_winit_circle.rs
+++ b/render/examples/raw_wgpu_winit_circle.rs
@@ -72,8 +72,8 @@ fn main() {
     // Bits of wgpu are async so we need an async blocker here
     executor::block_on(async move {
         // Create a new WGPU instance, surface and adapter
-        let instance    = wgpu::Instance::new(wgpu::Backends::all());
-        let surface     = unsafe { instance.create_surface(&window) };
+        let instance    = wgpu::Instance::new(Default::default());
+        let surface     = unsafe { instance.create_surface(&window).expect("Failed to create surface") };
         let adapter     = instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference:       wgpu::PowerPreference::default(),
             force_fallback_adapter: false,

--- a/render/examples/raw_wgpu_winit_triangle.rs
+++ b/render/examples/raw_wgpu_winit_triangle.rs
@@ -52,8 +52,8 @@ fn main() {
     // Bits of wgpu are async so we need an async blocker here
     executor::block_on(async move {
         // Create a new WGPU instance, surface and adapter
-        let instance    = wgpu::Instance::new(wgpu::Backends::all());
-        let surface     = unsafe { instance.create_surface(&window) };
+        let instance    = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
+        let surface     = unsafe { instance.create_surface(&window).expect("Failed to create surface") };
         let adapter     = instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference:       wgpu::PowerPreference::default(),
             force_fallback_adapter: false,

--- a/render/shaders/simple/simple.wgsl
+++ b/render/shaders/simple/simple.wgsl
@@ -15,13 +15,13 @@ fn simple_vertex_shader(
 ) -> RasterData {
     var result: RasterData;
 
-    var color = vec4<f32>(f32(color[0]), f32(color[1]), f32(color[2]), f32(color[3]));
-    color[0]        /= 255.0;
-    color[1]        /= 255.0;
-    color[2]        /= 255.0;
-    color[3]        /= 255.0;
+    var color_r = vec4<f32>(f32(color[0]), f32(color[1]), f32(color[2]), f32(color[3]));
+    color_r[0]        /= 255.0;
+    color_r[1]        /= 255.0;
+    color_r[2]        /= 255.0;
+    color_r[3]        /= 255.0;
 
-    result.color    = color;
+    result.color    = color_r;
     result.pos      = vec4<f32>(pos[0], pos[1], 0.0, 1.0) * transform;
 
     return result;

--- a/render/shaders/texture/gradient.wgsl
+++ b/render/shaders/texture/gradient.wgsl
@@ -33,16 +33,16 @@ fn gradient_vertex_shader(
 ) -> RasterData {
     var result: RasterData;
 
-    var color = vec4<f32>(f32(color[0]), f32(color[1]), f32(color[2]), f32(color[3]));
-    color[0] /= 255.0;
-    color[1] /= 255.0;
-    color[2] /= 255.0;
-    color[3] /= 255.0;
+    var color_r = vec4<f32>(f32(color[0]), f32(color[1]), f32(color[2]), f32(color[3]));
+    color_r[0] /= 255.0;
+    color_r[1] /= 255.0;
+    color_r[2] /= 255.0;
+    color_r[3] /= 255.0;
 
-    let tex_coord       = texture_position(pos, tex_coord, texture_settings.transform);
+    let tex_coord_r     = texture_position(pos, tex_coord, texture_settings.transform);
 
-    result.color        = color;
-    result.tex_coord    = tex_coord;
+    result.color        = color_r;
+    result.tex_coord    = tex_coord_r;
     result.pos          = vec4<f32>(pos[0], pos[1], 0.0, 1.0) * transform;
 
     return result;

--- a/render/shaders/texture/texture.wgsl
+++ b/render/shaders/texture/texture.wgsl
@@ -25,16 +25,16 @@ fn texture_vertex_shader(
 ) -> RasterData {
     var result: RasterData;
 
-    var color = vec4<f32>(f32(color[0]), f32(color[1]), f32(color[2]), f32(color[3]));
-    color[0] /= 255.0;
-    color[1] /= 255.0;
-    color[2] /= 255.0;
-    color[3] /= 255.0;
+    var color_r = vec4<f32>(f32(color[0]), f32(color[1]), f32(color[2]), f32(color[3]));
+    color_r[0] /= 255.0;
+    color_r[1] /= 255.0;
+    color_r[2] /= 255.0;
+    color_r[3] /= 255.0;
 
-    let tex_coord       = texture_position(pos, tex_coord, texture_settings.transform);
+    let tex_coord_r     = texture_position(pos, tex_coord, texture_settings.transform);
 
-    result.color        = color;
-    result.tex_coord    = tex_coord;
+    result.color        = color_r;
+    result.tex_coord    = tex_coord_r;
     result.pos          = vec4<f32>(pos[0], pos[1], 0.0, 1.0) * transform;
 
     return result;

--- a/render/src/gl_renderer/mod.rs
+++ b/render/src/gl_renderer/mod.rs
@@ -15,12 +15,4 @@ mod standard_shader_programs;
 pub use self::gl_renderer::*;
 
 pub use self::error::*;
-pub use self::vertex_array::*;
-pub use self::buffer::*;
-pub use self::vertex::*;
-pub use self::shader::*;
-pub use self::texture::*;
 pub use self::render_target::*;
-pub use self::shader_program::*;
-pub use self::shader_uniforms::*;
-pub use self::standard_shader_programs::*;

--- a/render/src/lib.rs
+++ b/render/src/lib.rs
@@ -11,9 +11,9 @@ mod profiler;
 pub use self::action::*;
 pub use self::buffer::*;
 pub use self::offscreen::*;
-#[cfg(feature="gl")] pub use self::gl_renderer::{GlRenderer};
-#[cfg(feature="osx-metal")] pub use self::metal_renderer::{MetalRenderer};
-#[cfg(feature="render-wgpu")] pub use self::wgpu_renderer::{WgpuRenderer};
+#[cfg(feature="gl")] pub use self::gl_renderer::GlRenderer;
+#[cfg(feature="osx-metal")] pub use self::metal_renderer::MetalRenderer;
+#[cfg(feature="render-wgpu")] pub use self::wgpu_renderer::WgpuRenderer;
 
 #[cfg(feature="render-wgpu")]
 pub use wgpu;

--- a/render/src/offscreen/wgpu_offscreen.rs
+++ b/render/src/offscreen/wgpu_offscreen.rs
@@ -6,11 +6,10 @@ use crate::wgpu_renderer::*;
 
 use ::desync::*;
 use futures::prelude::*;
-use once_cell::sync::{Lazy};
+use once_cell::sync::Lazy;
 
 use wgpu;
 
-use std::num::*;
 use std::sync::*;
 
 static WGPU_BACKGROUND: Lazy<Desync<()>> = Lazy::new(|| Desync::new(()));

--- a/render/src/offscreen/wgpu_offscreen.rs
+++ b/render/src/offscreen/wgpu_offscreen.rs
@@ -42,7 +42,7 @@ struct WgpuOffscreenRenderTarget {
 ///
 pub async fn wgpu_initialize_offscreen_rendering() -> Result<impl OffscreenRenderContext, RenderInitError> {
     // Create a new WGPU instance and adapter
-    let instance    = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), dx12_shader_compiler: wgpu::Dx12Compiler::default() });
+    let instance    = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), dx12_shader_compiler: wgpu::Dx12Compiler::default(), ..Default::default() });
     let adapter     = instance.request_adapter(&wgpu::RequestAdapterOptions {
         power_preference:       wgpu::PowerPreference::default(),
         force_fallback_adapter: false,

--- a/render/src/wgpu_renderer/alpha_blend_filter.rs
+++ b/render/src/wgpu_renderer/alpha_blend_filter.rs
@@ -69,13 +69,14 @@ pub (crate) fn alpha_blend(device: &wgpu::Device, encoder: &mut wgpu::CommandEnc
             Some(wgpu::RenderPassColorAttachment {
                 view:           &target_view,
                 resolve_target: None,
-                ops:            wgpu::Operations { load: wgpu::LoadOp::Clear(wgpu::Color { r: 0.0, g: 0.0, b: 0.0, a: 0.0 }), store: true }
+                ops:            wgpu::Operations { load: wgpu::LoadOp::Clear(wgpu::Color { r: 0.0, g: 0.0, b: 0.0, a: 0.0 }), store: wgpu::StoreOp::Store },
             })
         ];
         let mut render_pass     = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label:                      Some("alpha_blend"),
             depth_stencil_attachment:   None,
             color_attachments:          &color_attachments,
+            ..Default::default()
         });
 
         // Draw the vertices

--- a/render/src/wgpu_renderer/blur_filter.rs
+++ b/render/src/wgpu_renderer/blur_filter.rs
@@ -101,13 +101,14 @@ pub (crate) fn blur_fixed(device: &wgpu::Device, encoder: &mut wgpu::CommandEnco
             Some(wgpu::RenderPassColorAttachment {
                 view:           &target_view,
                 resolve_target: None,
-                ops:            wgpu::Operations { load: wgpu::LoadOp::Clear(wgpu::Color { r: 0.0, g: 0.0, b: 0.0, a: 0.0 }), store: true }
+                ops:            wgpu::Operations { load: wgpu::LoadOp::Clear(wgpu::Color { r: 0.0, g: 0.0, b: 0.0, a: 0.0 }), store: wgpu::StoreOp::Store }
             })
         ];
         let mut render_pass     = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label:                      Some("blur_fixed"),
             depth_stencil_attachment:   None,
             color_attachments:          &color_attachments,
+            ..Default::default()
         });
 
         // Draw the vertices
@@ -222,13 +223,14 @@ pub (crate) fn blur_texture(device: &wgpu::Device, queue: &wgpu::Queue, encoder:
             Some(wgpu::RenderPassColorAttachment {
                 view:           &target_view,
                 resolve_target: None,
-                ops:            wgpu::Operations { load: wgpu::LoadOp::Clear(wgpu::Color { r: 0.0, g: 0.0, b: 0.0, a: 0.0 }), store: true }
+                ops:            wgpu::Operations { load: wgpu::LoadOp::Clear(wgpu::Color { r: 0.0, g: 0.0, b: 0.0, a: 0.0 }), store: wgpu::StoreOp::Store },
             })
         ];
         let mut render_pass     = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label:                      Some("blur_texture"),
             depth_stencil_attachment:   None,
             color_attachments:          &color_attachments,
+            ..Default::default()
         });
 
         // Draw the vertices

--- a/render/src/wgpu_renderer/displacement_map_filter.rs
+++ b/render/src/wgpu_renderer/displacement_map_filter.rs
@@ -92,13 +92,14 @@ pub (crate) fn displacement_map(device: &wgpu::Device, encoder: &mut wgpu::Comma
             Some(wgpu::RenderPassColorAttachment {
                 view:           &target_view,
                 resolve_target: None,
-                ops:            wgpu::Operations { load: wgpu::LoadOp::Clear(wgpu::Color { r: 0.0, g: 0.0, b: 0.0, a: 0.0 }), store: true }
+                ops:            wgpu::Operations { load: wgpu::LoadOp::Clear(wgpu::Color { r: 0.0, g: 0.0, b: 0.0, a: 0.0 }), store: wgpu::StoreOp::Store },
             })
         ];
         let mut render_pass     = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label:                      Some("displacement_map"),
             depth_stencil_attachment:   None,
             color_attachments:          &color_attachments,
+            ..Default::default()
         });
 
         // Draw the vertices

--- a/render/src/wgpu_renderer/mask_filter.rs
+++ b/render/src/wgpu_renderer/mask_filter.rs
@@ -78,13 +78,14 @@ pub (crate) fn mask(device: &wgpu::Device, encoder: &mut wgpu::CommandEncoder, m
             Some(wgpu::RenderPassColorAttachment {
                 view:           &target_view,
                 resolve_target: None,
-                ops:            wgpu::Operations { load: wgpu::LoadOp::Clear(wgpu::Color { r: 0.0, g: 0.0, b: 0.0, a: 0.0 }), store: true }
+                ops:            wgpu::Operations { load: wgpu::LoadOp::Clear(wgpu::Color { r: 0.0, g: 0.0, b: 0.0, a: 0.0 }), store: wgpu::StoreOp::Store },
             })
         ];
         let mut render_pass     = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label:                      Some("mask"),
             depth_stencil_attachment:   None,
             color_attachments:          &color_attachments,
+            ..Default::default()
         });
 
         // Draw the vertices

--- a/render/src/wgpu_renderer/reduce_filter.rs
+++ b/render/src/wgpu_renderer/reduce_filter.rs
@@ -7,7 +7,6 @@ use crate::buffer::*;
 use wgpu;
 
 use std::mem;
-use std::num::*;
 use std::sync::*;
 
 ///

--- a/render/src/wgpu_renderer/reduce_filter.rs
+++ b/render/src/wgpu_renderer/reduce_filter.rs
@@ -88,13 +88,14 @@ pub (crate) fn reduce_filter(device: &wgpu::Device, encoder: &mut wgpu::CommandE
             Some(wgpu::RenderPassColorAttachment {
                 view:           &target_view,
                 resolve_target: None,
-                ops:            wgpu::Operations { load: wgpu::LoadOp::Clear(wgpu::Color { r: 0.0, g: 0.0, b: 0.0, a: 0.0 }), store: true }
+                ops:            wgpu::Operations { load: wgpu::LoadOp::Clear(wgpu::Color { r: 0.0, g: 0.0, b: 0.0, a: 0.0 }), store: wgpu::StoreOp::Store },
             })
         ];
         let mut render_pass     = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label:                      Some("reduce_filter"),
             depth_stencil_attachment:   None,
             color_attachments:          &color_attachments,
+            ..Default::default()
         });
 
         // Draw the vertices

--- a/render/src/wgpu_renderer/render_pass_resources.rs
+++ b/render/src/wgpu_renderer/render_pass_resources.rs
@@ -99,7 +99,7 @@ impl RenderPassResources {
                 Some(wgpu::RenderPassColorAttachment {
                     view:           &**target_view,
                     resolve_target: None,
-                    ops:            wgpu::Operations { load: load_op, store: true }
+                    ops:            wgpu::Operations { load: load_op, store: wgpu::StoreOp::Store },
                 })
             ]
         } else {

--- a/render/src/wgpu_renderer/renderer_state.rs
+++ b/render/src/wgpu_renderer/renderer_state.rs
@@ -214,6 +214,7 @@ impl RendererState {
                 label:                      Some("run_render_pass"),
                 depth_stencil_attachment:   None,
                 color_attachments:          &resources.color_attachments(),
+                ..Default::default()
             });
 
             // Run all of the actions

--- a/render/src/wgpu_renderer/wgpu_renderer.rs
+++ b/render/src/wgpu_renderer/wgpu_renderer.rs
@@ -25,14 +25,14 @@ use flo_canvas;
 
 use wgpu;
 use wgpu::util;
-use wgpu::util::{DeviceExt};
+use wgpu::util::DeviceExt;
 
 use std::mem;
 use std::slice;
-use std::ops::{Range};
+use std::ops::Range;
 use std::sync::*;
-use std::collections::{HashMap};
-use std::ffi::{c_void};
+use std::collections::HashMap;
+use std::ffi::c_void;
 
 #[cfg(feature="profile")]
 use std::cell::*;
@@ -40,9 +40,9 @@ use std::cell::*;
 use std::rc::*;
 
 #[cfg(feature="wgpu-profiler")]
-use wgpu_profiler::{wgpu_profiler, GpuProfiler};
+use wgpu_profiler::{GpuProfiler, GpuProfilerSettings};
 #[cfg(feature="wgpu-profiler")]
-use std::path::{Path};
+use std::path::Path;
 
 ///
 /// Renderer that uses the `wgpu` abstract library as a render target
@@ -120,12 +120,12 @@ impl WgpuRenderer {
     ///
     pub fn from_surface(device: Arc<wgpu::Device>, queue: Arc<wgpu::Queue>, target_surface: Arc<wgpu::Surface>, target_adapter: Arc<wgpu::Adapter>) -> WgpuRenderer {
         #[cfg(feature="wgpu-profiler")]
-        let wgpu_profiler = GpuProfiler::new(4, queue.get_timestamp_period(), GpuProfiler::ALL_WGPU_TIMER_FEATURES);
+        let wgpu_profiler = GpuProfiler::new(GpuProfilerSettings { max_num_pending_frames: 4, ..Default::default()}).expect("Failed to create WGPU profiler");
 
         WgpuRenderer {
             adapter:                target_adapter,
             device:                 device.clone(),
-            queue:                  queue,
+            queue,
             target_surface:         Some(target_surface),
             target_format:          None,
             target_surface_texture: None,
@@ -147,7 +147,7 @@ impl WgpuRenderer {
             profiler:               Rc::new(RefCell::new(RenderProfiler::new())),
 
             #[cfg(feature="wgpu-profiler")]
-            wgpu_profiler:          wgpu_profiler,
+            wgpu_profiler,
         }
     }
     ///
@@ -155,12 +155,12 @@ impl WgpuRenderer {
     ///
     pub fn from_texture(device: Arc<wgpu::Device>, queue: Arc<wgpu::Queue>, target_texture: Arc<wgpu::Texture>, target_adapter: Arc<wgpu::Adapter>, texture_format: wgpu::TextureFormat, texture_size: (u32, u32)) -> WgpuRenderer {
         #[cfg(feature="wgpu-profiler")]
-        let wgpu_profiler = GpuProfiler::new(4, queue.get_timestamp_period(), GpuProfiler::ALL_WGPU_TIMER_FEATURES);
+        let wgpu_profiler = GpuProfiler::new(GpuProfilerSettings { max_num_pending_frames: 4, ..Default::default()}).expect("Failed to create WGPU profiler");
 
         WgpuRenderer {
             adapter:                target_adapter,
             device:                 device.clone(),
-            queue:                  queue,
+            queue,
             target_surface:         None,
             target_format:          Some(texture_format),
             target_surface_texture: None,
@@ -182,7 +182,7 @@ impl WgpuRenderer {
             profiler:               Rc::new(RefCell::new(RenderProfiler::new())),
 
             #[cfg(feature="wgpu-profiler")]
-            wgpu_profiler:          wgpu_profiler,
+            wgpu_profiler,
         }
     }
 
@@ -319,7 +319,7 @@ impl WgpuRenderer {
 
         // Rewrite the chrometrace file every frame (TODO: some other cadence/write multiple files)
         #[cfg(feature="wgpu-profiler")]
-        if let Some(profiling_data) = self.wgpu_profiler.process_finished_frame() {
+        if let Some(profiling_data) = self.wgpu_profiler.process_finished_frame(self.queue.get_timestamp_period()) {
             wgpu_profiler::chrometrace::write_chrometrace(Path::new("flo_draw_profile.json"), &profiling_data);
         }
         

--- a/render_canvas/examples/raw_wgpu_winit.rs
+++ b/render_canvas/examples/raw_wgpu_winit.rs
@@ -47,8 +47,8 @@ fn main() {
     // Bits of wgpu are async so we need an async blocker here
     executor::block_on(async move {
         // Create a new WGPU instance, surface and adapter
-        let instance    = wgpu::Instance::new(wgpu::Backends::all());
-        let surface     = unsafe { instance.create_surface(&window) };
+        let instance    = wgpu::Instance::new(Default::default());
+        let surface     = unsafe { instance.create_surface(&window).expect("Failed to create surface") };
         let adapter     = instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference:       wgpu::PowerPreference::default(),
             force_fallback_adapter: false,

--- a/render_canvas/src/renderer_stream.rs
+++ b/render_canvas/src/renderer_stream.rs
@@ -328,6 +328,7 @@ impl RenderCore {
     ///
     /// Draws some bounds using viewport coordinates
     ///
+    #[allow(dead_code)]
     fn render_debug_region(&mut self, active_transform: canvas::Transform2D, viewport_size: render::Size2D, debug_region: LayerBounds, invalid_bounds: &mut LayerBounds) -> Vec<render::RenderAction> {
         // Reverse the active transform (so we figure out coordinates that will map to the debug region)
         let render::Size2D(w, h)    = viewport_size;


### PR DESCRIPTION
This PR updates `wgpu` and `wgpu-profiler` to the latest versions.

It also fixes compilation issues for raw wgpu examples. Although the examples wouldn't work even with the old wgpu version (will open a separate issue for this).