### PR TITLE
feat: multicard support for linux offscren render

### DIFF
--- a/render/src/offscreen/opengl_egl_init.rs
+++ b/render/src/offscreen/opengl_egl_init.rs
@@ -36,7 +36,8 @@ struct EglOffscreenRenderContext {
 pub fn opengl_initialize_offscreen_rendering() -> Result<impl OffscreenRenderContext, RenderInitError> {
     unsafe {
         // Open the card0 file descriptor
-        let card0_file = CString::new("/dev/dri/card0").unwrap();
+        let card_number = std::env::var("FLO_CARD").unwrap_or("0".to_owned());
+        let card0_file = CString::new(format!("/dev/dri/card{card_number}")).unwrap();
         let card0 = open(card0_file.as_ptr(), O_RDWR);
         if card0 == 0 { Err(RenderInitError::CannotOpenGraphicsDevice)? }
 


### PR DESCRIPTION
Add support for multiple video cards through an environment variable `FLO_CARD` that can be set to the number of the card.

Example:
```bash
# Run with /dev/dri/card1
FLO_CARD=1 cargo run
```

This fixes a error on my machine, I don't have `card0`, it begins from `card1`. So, when I run some code without this changes it tries to get `card0` by default and It doesn't work.