### PR TITLE
Use base64 encoding with padding for the terminal renderer

### DIFF
--- a/render_software/src/render/terminal_render.rs
+++ b/render_software/src/render/terminal_render.rs
@@ -59,7 +59,7 @@ mod term_render {
             // TODO: check termial capabilities (we can fall back to an ASCII-art representation)
 
             // Convert to base64
-            let base64 = general_purpose::STANDARD_NO_PAD.encode(&png_data);
+            let base64 = general_purpose::STANDARD.encode(&png_data);
 
             // Write out the iterm escape sequence
             print!("\x1b]1337;File=inline=1:{}\x07", base64);


### PR DESCRIPTION
Hi. I've been poking around `flo_render_software` (specifically trying to extend it to work with CMYK, it's going well i think).

Since I don't have iTerm I tried running the examples with [Wezterm](https://wezterm.org) which supports the image protocol, but it only shows *some* of the images. Changing the encoder to use padded mode fixes this.

The iTerm docs don't specify whether padding should be used. I assume it works just the same but have nowhere to test.

In any case thank you for this wonderfully written library! I will probably annoy you some more in the near future if you'll allow me :)